### PR TITLE
Fix issue with mouse over on items and theme

### DIFF
--- a/Osiris.AssociateRecentWorkItems/RecentWorkItemsView.xaml
+++ b/Osiris.AssociateRecentWorkItems/RecentWorkItemsView.xaml
@@ -58,6 +58,28 @@
             </ListView.ContextMenu>
             <ListView.ItemContainerStyle>
                 <Style TargetType="ListViewItem">
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type ListViewItem}">
+                                <ControlTemplate.Triggers>
+                                    <Trigger Property="IsMouseOver"
+                                             Value="True">
+                                        <Setter Property="Background"
+                                                Value="{DynamicResource {x:Static vsshell:VsBrushes.CommandBarHoverKey}}" />
+                                    </Trigger>
+                                </ControlTemplate.Triggers>
+                                <Border BorderBrush="Transparent"
+                                        BorderThickness="0"
+                                        Background="{TemplateBinding Background}">
+                                    <GridViewRowPresenter HorizontalAlignment="Stretch"
+                                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                          Width="Auto"
+                                                          Margin="0,2"
+                                                          Content="{TemplateBinding Content}" />
+                                </Border>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
                     <Setter Property="Foreground" Value="{DynamicResource {x:Static vsshell:VsBrushes.ToolWindowTextKey}}"/>
                     <Setter Property="ToolTip">
                         <Setter.Value>


### PR DESCRIPTION
I fixed an issue with dark theme. Previous code used default wpf listviewitem color.
I used a tool from codeplex to find the color to bind: [https://vsthemecolorsviewer.codeplex.com/](https://vsthemecolorsviewer.codeplex.com/)

Blue theme:
![blue](https://cloud.githubusercontent.com/assets/10358735/9699531/b301ff84-53e6-11e5-9df4-b2c65873390c.png)

Dark theme:
![dark](https://cloud.githubusercontent.com/assets/10358735/9699535/c5b1862c-53e6-11e5-81f1-d439fe88c20e.png)

Light theme:
![light](https://cloud.githubusercontent.com/assets/10358735/9699537/cc8eb96a-53e6-11e5-90ff-0a10c7549d36.png)
